### PR TITLE
Export in outputs route tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,13 +84,13 @@ module "website" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.67 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.11 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.67 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.11 |
 
 ## Modules
 
@@ -138,6 +138,7 @@ No modules.
 | <a name="output_internet_gateway_id"></a> [internet\_gateway\_id](#output\_internet\_gateway\_id) | n/a |
 | <a name="output_is_management_network"></a> [is\_management\_network](#output\_is\_management\_network) | n/a |
 | <a name="output_management_cidr_block"></a> [management\_cidr\_block](#output\_management\_cidr\_block) | n/a |
+| <a name="output_route_table_all_ids"></a> [route\_table\_all\_ids](#output\_route\_table\_all\_ids) | n/a |
 | <a name="output_subnet_all_ids"></a> [subnet\_all\_ids](#output\_subnet\_all\_ids) | n/a |
 | <a name="output_subnet_private_ids"></a> [subnet\_private\_ids](#output\_subnet\_private\_ids) | n/a |
 | <a name="output_subnet_public_ids"></a> [subnet\_public\_ids](#output\_subnet\_public\_ids) | n/a |

--- a/outputs.tf
+++ b/outputs.tf
@@ -34,3 +34,9 @@ output "subnet_public_ids" {
     for subnet in aws_subnet.all : subnet.id if subnet.map_public_ip_on_launch == true
   ]
 }
+
+output "route_table_all_ids" {
+  value = [
+    for subnet in aws_subnet.all : aws_route_table.all[subnet.cidr_block].id
+  ]
+}

--- a/test_data/service_network/outputs.tf
+++ b/test_data/service_network/outputs.tf
@@ -17,3 +17,7 @@ output "internet_gateway_id" {
 output "vpc_id" {
   value = module.test_network.vpc_id
 }
+
+output "route_table_all" {
+  value = module.test_network.route_table_all_ids
+}

--- a/vpc.tf
+++ b/vpc.tf
@@ -13,4 +13,7 @@ resource "aws_vpc" "vpc" {
       "management"  = local.is_management_network
     }
   )
+  lifecycle {
+    create_before_destroy = true
+  }
 }


### PR DESCRIPTION
The module create a route table to ensure TCP/IP connectivity netweem
the create VPC and the management VPC.
A user might want to extend the created route tables. To enable that,
export the route table ids in an output variable.
