### PR TITLE
Add input variable enable_resource_name_dns_a_record_on_launch

### DIFF
--- a/subnets.tf
+++ b/subnets.tf
@@ -1,9 +1,10 @@
 resource "aws_subnet" "all" {
-  for_each                = { for s in var.subnets : s.cidr => s }
-  cidr_block              = each.value.cidr
-  vpc_id                  = aws_vpc.vpc.id
-  availability_zone       = each.value.availability-zone
-  map_public_ip_on_launch = each.value.map_public_ip_on_launch
+  for_each                                    = { for s in var.subnets : s.cidr => s }
+  cidr_block                                  = each.value.cidr
+  vpc_id                                      = aws_vpc.vpc.id
+  availability_zone                           = each.value.availability-zone
+  map_public_ip_on_launch                     = each.value.map_public_ip_on_launch
+  enable_resource_name_dns_a_record_on_launch = var.enable_resource_name_dns_a_record_on_launch
 
   tags = merge(
     var.tags,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,7 +60,14 @@ def update_source(path, module_path):
 
 
 @contextmanager
-def create_tf_conf(tf_dir, region, management_cidr_block, vpc_cidr_block, subnets, restrict_all_traffic: bool):
+def create_tf_conf(
+    tf_dir,
+    region,
+    management_cidr_block,
+    vpc_cidr_block,
+    subnets,
+    restrict_all_traffic: bool,
+):
     config_file = osp.join(tf_dir, "terraform.tfvars")
     try:
         with open(config_file, "w") as fd:

--- a/tests/test_one_vpc.py
+++ b/tests/test_one_vpc.py
@@ -17,7 +17,7 @@ from tests.conftest import create_tf_conf, TRACE_TERRAFORM, DESTROY_AFTER
             "expected_subnet_all_count",
             "expected_subnet_public_count",
             "expected_subnet_private_count",
-            "restrict_all_traffic"
+            "restrict_all_traffic",
         ]
     ),
     [
@@ -113,7 +113,7 @@ def test_service_network(
     expected_subnet_all_count,
     expected_subnet_public_count,
     expected_subnet_private_count,
-    restrict_all_traffic
+    restrict_all_traffic,
 ):
     ec2_client = ec2_client_map[region]
 
@@ -124,7 +124,7 @@ def test_service_network(
         management_cidr_block=management_cidr_block,
         vpc_cidr_block=vpc_cidr_block,
         subnets=subnets,
-        restrict_all_traffic=restrict_all_traffic
+        restrict_all_traffic=restrict_all_traffic,
     ):
         with terraform_apply(
             tf_dir,

--- a/variables.tf
+++ b/variables.tf
@@ -9,6 +9,11 @@ variable "enable_dns_hostnames" {
   type        = bool
   default     = false
 }
+variable "enable_resource_name_dns_a_record_on_launch" {
+  description = "Indicates whether to respond to DNS queries for instance hostnames with DNS A records."
+  type        = bool
+  default     = false
+}
 
 variable "environment" {
   description = "Name of environment"


### PR DESCRIPTION
By default, instance hostname doesn't resolve. Let user change this behavior.
Doesn't change the default behavior.
