### PR TITLE
Allow one NAT per VPC

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ myst-parser ~= 2.0
 pytest ~= 8.3
 Sphinx ~= 6.0
 sphinx-rtd-theme ~= 1.2
+infrahouse-core ~= 0.15

--- a/routing.tf
+++ b/routing.tf
@@ -41,8 +41,7 @@ resource "aws_route" "subnet_public" {
 
 resource "aws_route" "subnet_private" {
   for_each = {
-    for s in local.subnets_private : s.cidr => s
-    if s.forward_to != null
+    for s in local.subnets_private : s.cidr => s if s.forward_to != null
   }
   route_table_id         = aws_route_table.all[each.key].id
   destination_cidr_block = "0.0.0.0/0"

--- a/test_data/service_network/clients.tf
+++ b/test_data/service_network/clients.tf
@@ -81,8 +81,8 @@ resource "aws_security_group" "client" {
 
 
 resource "aws_instance" "client_instance" {
-  for_each  = toset(module.test_network.subnet_all_ids)
-  subnet_id = each.key
+  count     = length(module.test_network.subnet_all_ids)
+  subnet_id = module.test_network.subnet_all_ids[count.index]
   launch_template {
     id      = aws_launch_template.client.id
     version = "$Latest"

--- a/test_data/service_network/clients.tf
+++ b/test_data/service_network/clients.tf
@@ -1,0 +1,94 @@
+data "aws_iam_policy_document" "client-permissions" {
+  statement {
+    actions   = ["sts:getCallerIdentity"]
+    resources = ["*"]
+  }
+}
+
+module "instance-profile" {
+  source       = "registry.infrahouse.com/infrahouse/instance-profile/aws"
+  version      = "1.8.1"
+  permissions  = data.aws_iam_policy_document.client-permissions.json
+  profile_name = "service-network-client"
+}
+
+resource "tls_private_key" "client" {
+  algorithm = "RSA"
+}
+
+resource "aws_key_pair" "client" {
+  key_name_prefix = "client-generated-"
+  public_key      = tls_private_key.client.public_key_openssh
+}
+
+
+resource "aws_launch_template" "client" {
+  name_prefix   = "client-"
+  instance_type = "t3a.micro"
+  key_name      = aws_key_pair.client.key_name
+  image_id      = data.aws_ami.ubuntu_pro.id
+  iam_instance_profile {
+    arn = module.instance-profile.instance_profile_arn
+  }
+  block_device_mappings {
+    device_name = data.aws_ami.ubuntu_pro.root_device_name
+    ebs {
+      volume_size           = 8
+      delete_on_termination = true
+      encrypted             = true
+    }
+  }
+  metadata_options {
+    http_tokens   = "required"
+    http_endpoint = "enabled"
+  }
+  vpc_security_group_ids = [
+    aws_security_group.client.id
+  ]
+  tag_specifications {
+    resource_type = "volume"
+    tags = merge(
+      data.aws_default_tags.provider.tags,
+    )
+  }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = merge(
+      data.aws_default_tags.provider.tags,
+    )
+  }
+}
+
+resource "aws_security_group" "client" {
+  vpc_id      = module.test_network.vpc_id
+  name_prefix = "client"
+  description = "Service network client security group"
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"          // All protocols
+    cidr_blocks = ["0.0.0.0/0"] // Allow all incoming traffic
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"          // All protocols
+    cidr_blocks = ["0.0.0.0/0"] // Allow all outgoing traffic
+  }
+}
+
+
+resource "aws_instance" "client_instance" {
+  for_each  = toset(module.test_network.subnet_all_ids)
+  subnet_id = each.key
+  launch_template {
+    id      = aws_launch_template.client.id
+    version = "$Latest"
+  }
+  vpc_security_group_ids = [
+    aws_security_group.client.id
+  ]
+
+}

--- a/test_data/service_network/data_sources.tf
+++ b/test_data/service_network/data_sources.tf
@@ -1,0 +1,28 @@
+data "aws_default_tags" "provider" {}
+data "aws_ami" "ubuntu_pro" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = [local.ami_name_pattern_pro]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name = "state"
+    values = [
+      "available"
+    ]
+  }
+
+  owners = ["099720109477"] # Canonical
+}

--- a/test_data/service_network/locals.tf
+++ b/test_data/service_network/locals.tf
@@ -1,0 +1,6 @@
+locals {
+  ubuntu_codename      = "noble"
+  ami_name_pattern_pro = "ubuntu-pro-server/images/hvm-ssd-gp3/ubuntu-${local.ubuntu_codename}-*"
+
+  ami_id = data.aws_ami.ubuntu_pro.id
+}

--- a/test_data/service_network/outputs.tf
+++ b/test_data/service_network/outputs.tf
@@ -24,7 +24,5 @@ output "route_table_all" {
 
 output "client_instances" {
   description = "Map with subnet id as key and client instance id as value"
-  value = {
-    for subnet_id in module.test_network.subnet_all_ids : subnet_id => aws_instance.client_instance[subnet_id].id
-  }
+  value       = aws_instance.client_instance[*].id
 }

--- a/test_data/service_network/outputs.tf
+++ b/test_data/service_network/outputs.tf
@@ -21,3 +21,10 @@ output "vpc_id" {
 output "route_table_all" {
   value = module.test_network.route_table_all_ids
 }
+
+output "client_instances" {
+  description = "Map with subnet id as key and client instance id as value"
+  value = {
+    for subnet_id in module.test_network.subnet_all_ids : subnet_id => aws_instance.client_instance[subnet_id].id
+  }
+}

--- a/test_data/service_network/variables.tf
+++ b/test_data/service_network/variables.tf
@@ -18,13 +18,18 @@ variable "management_cidr_block" {
 
 variable "subnets" {
   description = "List of subnets in the VPC"
-  type = list(object({
-    cidr                    = string
-    availability-zone       = string
-    map_public_ip_on_launch = bool
-    create_nat              = bool
-    forward_to              = string
-  }))
+  type = list(
+    object(
+      {
+        cidr                    = string
+        availability-zone       = string
+        map_public_ip_on_launch = optional(bool, false)
+        create_nat              = optional(bool, false)
+        forward_to              = optional(string, false)
+        tags                    = optional(map(string), {})
+      }
+    )
+  )
   default = []
 }
 

--- a/tests/test_one_vpc.py
+++ b/tests/test_one_vpc.py
@@ -222,7 +222,7 @@ def test_service_network(
             assert (
                 len(tf_out["subnets_private"]["value"]) == expected_subnet_private_count
             )
-            for instance_id in tf_out["client_instances"]["value"].values():
+            for instance_id in tf_out["client_instances"]["value"]:
                 assert (
                     EC2Instance(
                         instance_id=instance_id,

--- a/tests/test_one_vpc.py
+++ b/tests/test_one_vpc.py
@@ -1,6 +1,8 @@
 from pprint import pformat
 
 import pytest
+from infrahouse_core.aws import get_client
+from infrahouse_core.aws.ec2_instance import EC2Instance
 from infrahouse_toolkit.terraform import terraform_apply
 
 from tests.conftest import create_tf_conf
@@ -106,6 +108,42 @@ from tests.conftest import create_tf_conf
             True,  # restrict_all_traffic
             True,  # enable_vpc_flow_logs
         ),
+        # One VPC with four subnets and one NAT gateway
+        (
+            "us-east-1",
+            "10.1.0.0/16",
+            "10.1.0.0/16",
+            """[
+                    {
+                      cidr                    = "10.1.0.0/24"
+                      availability-zone       = "us-east-1a"
+                      map_public_ip_on_launch = true
+                      create_nat              = true
+                    },
+                    {
+                      cidr                    = "10.1.1.0/24"
+                      availability-zone       = "us-east-1a"
+                      forward_to              = "10.1.0.0/24"
+                    },
+                    {
+                      cidr                    = "10.1.2.0/24"
+                      availability-zone       = "us-east-1b"
+                      map_public_ip_on_launch = true
+                    },
+                    {
+                      cidr                    = "10.1.3.0/24"
+                      availability-zone       = "us-east-1b"
+                      forward_to              = "10.1.0.0/24"
+                    }
+                  ]
+                  """,
+            1,  # expected_nat_gateways_count
+            4,  # expected_subnet_all_count
+            2,  # expected_subnet_public_count
+            2,  # expected_subnet_private_count
+            True,  # restrict_all_traffic
+            False,  # enable_vpc_flow_logs
+        ),
     ],
 )
 def test_service_network(
@@ -184,3 +222,15 @@ def test_service_network(
             assert (
                 len(tf_out["subnets_private"]["value"]) == expected_subnet_private_count
             )
+            for instance_id in tf_out["client_instances"]["value"].values():
+                assert (
+                    EC2Instance(
+                        instance_id=instance_id,
+                        region=region,
+                        ec2_client=ec2,
+                        ssm_client=get_client(
+                            "ssm", region=region, role_arn=test_role_arn
+                        ),
+                    ).execute_command("ping -c 1 google.com")[0]
+                    == 0
+                )

--- a/variables.tf
+++ b/variables.tf
@@ -44,9 +44,9 @@ variable "subnets" {
       {
         cidr                    = string
         availability-zone       = string
-        map_public_ip_on_launch = bool
-        create_nat              = bool
-        forward_to              = string
+        map_public_ip_on_launch = optional(bool, false)
+        create_nat              = optional(bool, false)
+        forward_to              = optional(string, null)
         tags                    = optional(map(string), {})
       }
     )


### PR DESCRIPTION
This is to support configurations when there are two or more private
subnets and all of them are routed via a single NAT gateway.

* Make map_public_ip_on_launch, create_nat, forward_to optional
* Test that an instance in every subnet has access to Internet
