### PR TITLE
Support AWS provider versions 5.* and 6.* with dynamic availability zone handling

### DIFF
--- a/.github/workflows/terraform-CI.yml
+++ b/.github/workflows/terraform-CI.yml
@@ -8,14 +8,19 @@ permissions:
   id-token: write  # This is required for requesting the JWT
   contents: read
 
+concurrency:
+  group: aws-control
+  cancel-in-progress: false
+
 jobs:
   terraform:
     name: 'Terraform Test'
-    runs-on: ubuntu-latest
+    runs-on: ["self-hosted", "Linux", "noble"]
     environment: production
     timeout-minutes: 120
     env:
       GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+      ROLE_ARN: "arn:aws:iam::303467602807:role/service-network-tester"
 
     # Use the Bash shell regardless whether the GitHub Actions runner
     # is ubuntu-latest, macos-latest, or windows-latest
@@ -31,7 +36,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: "arn:aws:iam::303467602807:role/service-network-tester"
+          role-to-assume: ${{ env.ROLE_ARN }}
           role-session-name: "terraform-aws-service-network-ci"
           aws-region: "us-west-1"
 
@@ -40,6 +45,11 @@ jobs:
         uses: hashicorp/setup-terraform@v2
         with:
           terraform_wrapper: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
 
       # Prepare Python environment
       - name: Setup Python Environment

--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,8 @@ test:  ## Run tests on the module
 
 .PHONY: bootstrap
 bootstrap: ## bootstrap the development environment
-	pip install -U "pip ~= 23.1"
-	pip install -U "setuptools ~= 68.0"
+	pip install -U "pip ~= 25.2"
+	pip install -U "setuptools ~= 80.0"
 	pip install -r requirements.txt
 
 BROWSER := python -c "$$BROWSER_PYSCRIPT"
@@ -53,4 +53,3 @@ docs: ## generate Sphinx HTML documentation, including API docs
 	$(MAKE) -C docs clean
 	$(MAKE) -C docs html
 	$(BROWSER) docs/_build/html/index.html
-

--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ module "website" {
       map_public_ip_on_launch = true
       create_nat              = true
       forward_to              = null
-
     },
     {
       cidr                    = "10.3.1.0/24"
@@ -91,13 +90,13 @@ module "website" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.11 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.11, < 7.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.11 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.11, < 7.0 |
 
 ## Modules
 
@@ -122,6 +121,7 @@ No modules.
 | [aws_route_table_association.private_rt_assoc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
 | [aws_s3_bucket.vpc_flow_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_lifecycle_configuration.vpc_flow_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
+| [aws_s3_bucket_policy.vpc_flow_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_public_access_block.public_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_server_side_encryption_configuration.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_s3_bucket_versioning.enabled](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
@@ -132,6 +132,8 @@ No modules.
 | [aws_vpc_peering_connection.link_to_management](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_peering_connection) | resource |
 | [aws_vpc_security_group_egress_rule.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_egress_rule) | resource |
 | [aws_vpc_security_group_ingress_rule.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.vpc_flow_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_route_tables.mgmt_route_tables](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route_tables) | data source |
 | [aws_vpc.management_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
@@ -140,30 +142,30 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_enable_dns_hostnames"></a> [enable\_dns\_hostnames](#input\_enable\_dns\_hostnames) | A boolean flag to enable/disable DNS hostnames in the VPC. Defaults false. | `bool` | `true` | no |
+| <a name="input_enable_dns_hostnames"></a> [enable\_dns\_hostnames](#input\_enable\_dns\_hostnames) | A boolean flag to enable/disable DNS hostnames in the VPC. Defaults true. | `bool` | `true` | no |
 | <a name="input_enable_dns_support"></a> [enable\_dns\_support](#input\_enable\_dns\_support) | A boolean flag to enable/disable DNS support in the VPC. Defaults true. | `bool` | `true` | no |
 | <a name="input_enable_resource_name_dns_a_record_on_launch"></a> [enable\_resource\_name\_dns\_a\_record\_on\_launch](#input\_enable\_resource\_name\_dns\_a\_record\_on\_launch) | Indicates whether to respond to DNS queries for instance hostnames with DNS A records. | `bool` | `false` | no |
-| <a name="input_enable_vpc_flow_logs"></a> [enable\_vpc\_flow\_logs](#input\_enable\_vpc\_flow\_logs) | Whether to enable VPC Flow Logs. Default, false. | `bool` | `true` | no |
+| <a name="input_enable_vpc_flow_logs"></a> [enable\_vpc\_flow\_logs](#input\_enable\_vpc\_flow\_logs) | Whether to enable VPC Flow Logs. Default, true. | `bool` | `true` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Name of environment | `string` | `"development"` | no |
-| <a name="input_management_cidr_block"></a> [management\_cidr\_block](#input\_management\_cidr\_block) | Management VPC cidr block | `any` | n/a | yes |
+| <a name="input_management_cidr_block"></a> [management\_cidr\_block](#input\_management\_cidr\_block) | Management VPC cidr block | `string` | n/a | yes |
 | <a name="input_restrict_all_traffic"></a> [restrict\_all\_traffic](#input\_restrict\_all\_traffic) | Whether the default security group should deny all traffic | `bool` | `true` | no |
-| <a name="input_service_name"></a> [service\_name](#input\_service\_name) | Descriptive name of a service that will use this VPC | `any` | n/a | yes |
-| <a name="input_subnets"></a> [subnets](#input\_subnets) | List of subnets in the VPC | <pre>list(<br/>    object(<br/>      {<br/>        cidr                    = string<br/>        availability-zone       = string<br/>        map_public_ip_on_launch = bool<br/>        create_nat              = bool<br/>        forward_to              = string<br/>        tags                    = optional(map(string), {})<br/>      }<br/>    )<br/>  )</pre> | `[]` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to each resource | `map` | `{}` | no |
-| <a name="input_vpc_cidr_block"></a> [vpc\_cidr\_block](#input\_vpc\_cidr\_block) | Block of IP addresses used for this VPC | `any` | n/a | yes |
+| <a name="input_service_name"></a> [service\_name](#input\_service\_name) | Descriptive name of a service that will use this VPC | `string` | n/a | yes |
+| <a name="input_subnets"></a> [subnets](#input\_subnets) | List of subnets in the VPC | <pre>list(<br/>    object(<br/>      {<br/>        cidr                    = string<br/>        availability-zone       = string<br/>        map_public_ip_on_launch = optional(bool, false)<br/>        create_nat              = optional(bool, false)<br/>        forward_to              = optional(string, null)<br/>        tags                    = optional(map(string), {})<br/>      }<br/>    )<br/>  )</pre> | `[]` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to each resource | `map(string)` | `{}` | no |
+| <a name="input_vpc_cidr_block"></a> [vpc\_cidr\_block](#input\_vpc\_cidr\_block) | Block of IP addresses used for this VPC | `string` | n/a | yes |
 | <a name="input_vpc_flow_retention_days"></a> [vpc\_flow\_retention\_days](#input\_vpc\_flow\_retention\_days) | Retention period for VPC flow logs in S3 bucket. | `number` | `7` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_internet_gateway_id"></a> [internet\_gateway\_id](#output\_internet\_gateway\_id) | n/a |
-| <a name="output_is_management_network"></a> [is\_management\_network](#output\_is\_management\_network) | n/a |
-| <a name="output_management_cidr_block"></a> [management\_cidr\_block](#output\_management\_cidr\_block) | n/a |
-| <a name="output_route_table_all_ids"></a> [route\_table\_all\_ids](#output\_route\_table\_all\_ids) | n/a |
-| <a name="output_subnet_all_ids"></a> [subnet\_all\_ids](#output\_subnet\_all\_ids) | n/a |
-| <a name="output_subnet_private_ids"></a> [subnet\_private\_ids](#output\_subnet\_private\_ids) | n/a |
-| <a name="output_subnet_public_ids"></a> [subnet\_public\_ids](#output\_subnet\_public\_ids) | n/a |
-| <a name="output_vpc_cidr_block"></a> [vpc\_cidr\_block](#output\_vpc\_cidr\_block) | n/a |
+| <a name="output_internet_gateway_id"></a> [internet\_gateway\_id](#output\_internet\_gateway\_id) | The ID of the Internet Gateway attached to the VPC |
+| <a name="output_is_management_network"></a> [is\_management\_network](#output\_is\_management\_network) | Boolean indicating whether this is a management network |
+| <a name="output_management_cidr_block"></a> [management\_cidr\_block](#output\_management\_cidr\_block) | The CIDR block of the management VPC |
+| <a name="output_route_table_all_ids"></a> [route\_table\_all\_ids](#output\_route\_table\_all\_ids) | List of IDs of all route tables |
+| <a name="output_subnet_all_ids"></a> [subnet\_all\_ids](#output\_subnet\_all\_ids) | List of IDs of all subnets |
+| <a name="output_subnet_private_ids"></a> [subnet\_private\_ids](#output\_subnet\_private\_ids) | List of IDs of private subnets |
+| <a name="output_subnet_public_ids"></a> [subnet\_public\_ids](#output\_subnet\_public\_ids) | List of IDs of public subnets |
+| <a name="output_vpc_cidr_block"></a> [vpc\_cidr\_block](#output\_vpc\_cidr\_block) | The CIDR block of the VPC |
 | <a name="output_vpc_flow_bucket_name"></a> [vpc\_flow\_bucket\_name](#output\_vpc\_flow\_bucket\_name) | S3 bucket name with VPC Flow logs if enabled |
-| <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | n/a |
+| <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | The ID of the VPC |

--- a/locals.tf
+++ b/locals.tf
@@ -11,6 +11,7 @@ locals {
     var.tags
   )
 
+
   is_management_network = var.management_cidr_block == var.vpc_cidr_block
   subnets_with_nat      = [for subnet in var.subnets : subnet if subnet.create_nat]
   subnets_without_nat   = [for subnet in var.subnets : subnet if !subnet.create_nat]

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,41 +1,50 @@
 output "internet_gateway_id" {
-  value = aws_internet_gateway.ig.id
+  description = "The ID of the Internet Gateway attached to the VPC"
+  value       = aws_internet_gateway.ig.id
 }
 
 output "is_management_network" {
-  value = local.is_management_network
+  description = "Boolean indicating whether this is a management network"
+  value       = local.is_management_network
 }
 
 output "management_cidr_block" {
-  value = var.management_cidr_block
+  description = "The CIDR block of the management VPC"
+  value       = var.management_cidr_block
 }
 
 output "vpc_cidr_block" {
-  value = var.vpc_cidr_block
+  description = "The CIDR block of the VPC"
+  value       = var.vpc_cidr_block
 }
 
 output "vpc_id" {
-  value = aws_vpc.vpc.id
+  description = "The ID of the VPC"
+  value       = aws_vpc.vpc.id
 }
 
 output "subnet_all_ids" {
+  description = "List of IDs of all subnets"
   value = [
     for subnet in aws_subnet.all : subnet.id
   ]
 }
 output "subnet_private_ids" {
+  description = "List of IDs of private subnets"
   value = [
     for subnet in aws_subnet.all : subnet.id if !subnet.map_public_ip_on_launch
   ]
 }
 
 output "subnet_public_ids" {
+  description = "List of IDs of public subnets"
   value = [
     for subnet in aws_subnet.all : subnet.id if subnet.map_public_ip_on_launch
   ]
 }
 
 output "route_table_all_ids" {
+  description = "List of IDs of all route tables"
   value = [
     for subnet in aws_subnet.all : aws_route_table.all[subnet.cidr_block].id
   ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,2 @@
-black ~= 25.0
-boto3 ~= 1.26
-infrahouse-toolkit ~= 2.16
-pytest-infrahouse ~= 0.9
-myst-parser ~= 2.0
-pytest ~= 8.3
-Sphinx ~= 6.0
-sphinx-rtd-theme ~= 1.2
-infrahouse-core ~= 0.15
+infrahouse-core ~= 0.17
+pytest-infrahouse ~= 0.10

--- a/terraform.tf
+++ b/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.11"
+      version = ">= 5.11, < 7.0"
     }
   }
 }

--- a/test_data/service_network/.gitignore
+++ b/test_data/service_network/.gitignore
@@ -1,0 +1,9 @@
+.terraform
+.terraform.lock.hcl
+terraform.tfstate
+terraform.tfstate.backup
+/.pytest_cache/
+__pycache__
+/tf-apply-trace.txt
+/tf-destroy-trace.txt
+terraform.tf

--- a/test_data/service_network/clients.tf
+++ b/test_data/service_network/clients.tf
@@ -7,7 +7,7 @@ data "aws_iam_policy_document" "client-permissions" {
 
 module "instance-profile" {
   source       = "registry.infrahouse.com/infrahouse/instance-profile/aws"
-  version      = "1.8.1"
+  version      = "1.9.0"
   permissions  = data.aws_iam_policy_document.client-permissions.json
   profile_name = "service-network-client"
 }

--- a/test_data/service_network/main.tf
+++ b/test_data/service_network/main.tf
@@ -1,3 +1,8 @@
+resource "random_string" "test-id" {
+  length  = 6
+  special = false
+}
+
 module "test_network" {
   source                = "./../../"
   environment           = var.environment
@@ -7,4 +12,7 @@ module "test_network" {
   subnets               = var.subnets
   restrict_all_traffic  = var.restrict_all_traffic
   enable_vpc_flow_logs  = var.enable_vpc_flow_logs
+  tags = {
+    test_id : random_string.test-id.result
+  }
 }

--- a/test_data/service_network/outputs.tf
+++ b/test_data/service_network/outputs.tf
@@ -26,3 +26,8 @@ output "client_instances" {
   description = "Map with subnet id as key and client instance id as value"
   value       = aws_instance.client_instance[*].id
 }
+
+output "test_id" {
+  description = "Random string that helps to find resources created by this module"
+  value       = random_string.test-id.result
+}

--- a/test_data/service_network/terraform.tf
+++ b/test_data/service_network/terraform.tf
@@ -1,8 +1,0 @@
-terraform {
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 5.11"
-    }
-  }
-}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,16 +4,12 @@ from os import path as osp
 
 from textwrap import dedent
 
-from infrahouse_toolkit.logging import setup_logging
-
-# "303467602807" is our test account
-TEST_ACCOUNT = "303467602807"
-# TEST_ROLE_ARN = "arn:aws:iam::303467602807:role/service-network-tester"
-DEFAULT_PROGRESS_INTERVAL = 10
+from infrahouse_core.logging import setup_logging
 
 
-LOG = logging.getLogger(__name__)
+LOG = logging.getLogger()
 setup_logging(LOG, debug=True)
+TERRAFORM_ROOT_DIR = "test_data"
 
 
 def update_source(path, module_path):
@@ -31,6 +27,7 @@ def create_tf_conf(
     management_cidr_block,
     vpc_cidr_block,
     subnets,
+    zone_names: list,
     restrict_all_traffic: bool,
     enable_vpc_flow_logs: bool = False,
     test_role_arn: str = None,
@@ -49,7 +46,18 @@ def create_tf_conf(
                     """
                 )
             )
-            fd.write(f"subnets = {subnets}")
+            subnets_fmt = f"subnets = {subnets}"
+            fd.write(
+                subnets_fmt.format(
+                    zone_a=zone_names[0],
+                    zone_b=zone_names[1] if len(zone_names) > 1 else zone_names[0],
+                    zone_c=(
+                        zone_names[2]
+                        if len(zone_names) > 2
+                        else zone_names[1] if len(zone_names) > 1 else zone_names[0]
+                    ),
+                )
+            )
             if test_role_arn:
                 fd.write(
                     dedent(

--- a/variables.tf
+++ b/variables.tf
@@ -5,7 +5,7 @@ variable "enable_dns_support" {
 }
 
 variable "enable_dns_hostnames" {
-  description = "A boolean flag to enable/disable DNS hostnames in the VPC. Defaults false."
+  description = "A boolean flag to enable/disable DNS hostnames in the VPC. Defaults true."
   type        = bool
   default     = true
 }
@@ -17,6 +17,7 @@ variable "enable_resource_name_dns_a_record_on_launch" {
 
 variable "environment" {
   description = "Name of environment"
+  type        = string
   default     = "development"
 }
 
@@ -25,6 +26,7 @@ variable "environment" {
 # needs to know block of IP addresses of the management VPC
 variable "management_cidr_block" {
   description = "Management VPC cidr block"
+  type        = string
 }
 
 variable "restrict_all_traffic" {
@@ -35,6 +37,7 @@ variable "restrict_all_traffic" {
 
 variable "service_name" {
   description = "Descriptive name of a service that will use this VPC"
+  type        = string
 }
 
 variable "subnets" {
@@ -55,21 +58,24 @@ variable "subnets" {
 }
 
 variable "enable_vpc_flow_logs" {
-  description = "Whether to enable VPC Flow Logs. Default, false."
+  description = "Whether to enable VPC Flow Logs. Default, true."
   type        = bool
   default     = true
 }
 
 variable "vpc_cidr_block" {
   description = "Block of IP addresses used for this VPC"
+  type        = string
 }
 
 variable "tags" {
   description = "Tags to apply to each resource"
+  type        = map(string)
   default     = {}
 }
 
 variable "vpc_flow_retention_days" {
   description = "Retention period for VPC flow logs in S3 bucket."
+  type        = number
   default     = 7
 }


### PR DESCRIPTION
  - Add parametrized testing for AWS provider versions ~> 5.11 and ~> 6.0
  - Replace hardcoded availability zones with dynamic fetching using boto3
  - Update conftest.py to handle regions with fewer than 3 availability zones
  - Fix variable type declarations and descriptions in variables.tf and README.md
  - Add comprehensive output descriptions for better module documentation

This ensures compatibility across different AWS regions (like us-west-1 with only 2 AZs)
while maintaining support for both AWS provider version families.
