### PR TITLE
feat: add cross-region replication for VPC flow logs bucket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ site/
 
 .claude/reviews
 .claude/*.local.json
+.claude/projects

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ can communicate internally and with the outside world, but not with other servic
 - Dynamic subnet creation with per-subnet control over public IP mapping, NAT gateways, and traffic forwarding
 - Hub-and-spoke topology: service networks automatically peer with a management VPC
 - VPC Flow Logs to S3 with configurable retention (defaults to 365 days for ISO/SOC compliance)
+- Cross-Region Replication (CRR) of VPC Flow Logs bucket for disaster recovery
 - S3 gateway endpoint for private S3 access
 - Restrictive default security group (configurable)
 - Internet Gateway and optional per-subnet NAT Gateways with Elastic IPs
@@ -35,6 +36,7 @@ module "network" {
   service_name          = "my-service"
   vpc_cidr_block        = "10.1.0.0/16"
   management_cidr_block = "10.1.0.0/16"
+  replication_region    = "us-east-1"
   subnets = [
     {
       cidr                    = "10.1.0.0/24"
@@ -72,6 +74,7 @@ module "management" {
   service_name          = "management"
   vpc_cidr_block        = "10.1.0.0/16"
   management_cidr_block = "10.1.0.0/16"
+  replication_region    = "us-east-1"
   subnets = [
     {
       cidr                    = "10.1.0.0/24"
@@ -108,6 +111,7 @@ module "website" {
   service_name          = "website"
   vpc_cidr_block        = "10.3.0.0/16"
   management_cidr_block = "10.1.0.0/16"
+  replication_region    = "us-east-1"
   subnets = [
     {
       cidr                    = "10.3.0.0/24"
@@ -138,13 +142,13 @@ a working example used in integration tests.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.11, < 7.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0, < 7.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.11, < 7.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0, < 7.0 |
 
 ## Modules
 
@@ -158,6 +162,8 @@ No modules.
 | [aws_default_security_group.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_security_group) | resource |
 | [aws_eip.nat_eip](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) | resource |
 | [aws_flow_log.vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/flow_log) | resource |
+| [aws_iam_role.replication](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.replication](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_internet_gateway.ig](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/internet_gateway) | resource |
 | [aws_nat_gateway.nat_gw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/nat_gateway) | resource |
 | [aws_route.default_main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
@@ -168,11 +174,18 @@ No modules.
 | [aws_route_table.all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
 | [aws_route_table_association.all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
 | [aws_s3_bucket.vpc_flow_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket.vpc_flow_logs_replica](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_lifecycle_configuration.vpc_flow_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
+| [aws_s3_bucket_lifecycle_configuration.vpc_flow_logs_replica](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
 | [aws_s3_bucket_policy.vpc_flow_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
+| [aws_s3_bucket_policy.vpc_flow_logs_replica](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_public_access_block.public_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_public_access_block.vpc_flow_logs_replica](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_replication_configuration.vpc_flow_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_replication_configuration) | resource |
 | [aws_s3_bucket_server_side_encryption_configuration.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
+| [aws_s3_bucket_server_side_encryption_configuration.vpc_flow_logs_replica](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_s3_bucket_versioning.enabled](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
+| [aws_s3_bucket_versioning.vpc_flow_logs_replica](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
 | [aws_subnet.all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_vpc.vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) | resource |
 | [aws_vpc_endpoint.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
@@ -181,7 +194,10 @@ No modules.
 | [aws_vpc_security_group_egress_rule.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_egress_rule) | resource |
 | [aws_vpc_security_group_ingress_rule.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.replication](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.replication_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.vpc_flow_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.vpc_flow_logs_replica](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_route_tables.mgmt_route_tables](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route_tables) | data source |
 | [aws_vpc.management_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
@@ -194,10 +210,10 @@ No modules.
 | <a name="input_enable_dns_hostnames"></a> [enable\_dns\_hostnames](#input\_enable\_dns\_hostnames) | A boolean flag to enable/disable DNS hostnames in the VPC. Defaults true. | `bool` | `true` | no |
 | <a name="input_enable_dns_support"></a> [enable\_dns\_support](#input\_enable\_dns\_support) | A boolean flag to enable/disable DNS support in the VPC. Defaults true. | `bool` | `true` | no |
 | <a name="input_enable_resource_name_dns_a_record_on_launch"></a> [enable\_resource\_name\_dns\_a\_record\_on\_launch](#input\_enable\_resource\_name\_dns\_a\_record\_on\_launch) | Indicates whether to respond to DNS queries for instance hostnames with DNS A records. | `bool` | `false` | no |
-| <a name="input_enable_vpc_flow_logs"></a> [enable\_vpc\_flow\_logs](#input\_enable\_vpc\_flow\_logs) | Whether to enable VPC Flow Logs. Default, true. | `bool` | `true` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Name of environment | `string` | n/a | yes |
 | <a name="input_flow_logs_force_destroy"></a> [flow\_logs\_force\_destroy](#input\_flow\_logs\_force\_destroy) | Whether to force destroy the VPC flow logs S3 bucket and all its contents on deletion. | `bool` | `false` | no |
 | <a name="input_management_cidr_block"></a> [management\_cidr\_block](#input\_management\_cidr\_block) | Management VPC cidr block | `string` | n/a | yes |
+| <a name="input_replication_region"></a> [replication\_region](#input\_replication\_region) | AWS region for cross-region replication of the VPC flow logs bucket. | `string` | n/a | yes |
 | <a name="input_restrict_all_traffic"></a> [restrict\_all\_traffic](#input\_restrict\_all\_traffic) | Whether the default security group should deny all traffic | `bool` | `true` | no |
 | <a name="input_service_name"></a> [service\_name](#input\_service\_name) | Descriptive name of a service that will use this VPC | `string` | n/a | yes |
 | <a name="input_subnets"></a> [subnets](#input\_subnets) | List of subnets in the VPC | <pre>list(<br/>    object(<br/>      {<br/>        cidr                    = string<br/>        availability_zone       = optional(string, null)<br/>        availability-zone       = optional(string, null) # Deprecated, use availability_zone<br/>        map_public_ip_on_launch = optional(bool, false)<br/>        create_nat              = optional(bool, false)<br/>        forward_to              = optional(string, null)<br/>        tags                    = optional(map(string), {})<br/>      }<br/>    )<br/>  )</pre> | `[]` | no |
@@ -217,7 +233,7 @@ No modules.
 | <a name="output_subnet_private_ids"></a> [subnet\_private\_ids](#output\_subnet\_private\_ids) | List of IDs of private subnets |
 | <a name="output_subnet_public_ids"></a> [subnet\_public\_ids](#output\_subnet\_public\_ids) | List of IDs of public subnets |
 | <a name="output_vpc_cidr_block"></a> [vpc\_cidr\_block](#output\_vpc\_cidr\_block) | The CIDR block of the VPC |
-| <a name="output_vpc_flow_bucket_name"></a> [vpc\_flow\_bucket\_name](#output\_vpc\_flow\_bucket\_name) | S3 bucket name with VPC Flow logs if enabled |
+| <a name="output_vpc_flow_bucket_name"></a> [vpc\_flow\_bucket\_name](#output\_vpc\_flow\_bucket\_name) | S3 bucket name with VPC Flow logs |
 | <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | The ID of the VPC |
 <!-- END_TF_DOCS -->
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,6 +42,15 @@ management_cidr_block = "10.1.0.0/16"  # same as vpc_cidr_block
 management_cidr_block = "10.1.0.0/16"  # different from vpc_cidr_block
 ```
 
+### `replication_region`
+
+The AWS region for cross-region replication of the VPC Flow Logs S3 bucket. Must be
+a different region than the one the module is deployed in.
+
+```hcl
+replication_region = "us-east-1"
+```
+
 ## Subnet Configuration
 
 ### `subnets`
@@ -113,10 +122,12 @@ default_security_group_cidr = null  # Default: null
 
 ### VPC Flow Logs
 
-```hcl
-# Enable/disable VPC Flow Logs
-enable_vpc_flow_logs = true  # Default: true
+VPC Flow Logs are always enabled. The flow logs bucket is automatically replicated
+to `replication_region` via Cross-Region Replication (CRR). A replica S3 bucket is
+created in the target region with matching encryption, versioning, lifecycle, and
+access policies.
 
+```hcl
 # Retention period in days (365 for ISO/SOC compliance)
 vpc_flow_retention_days = 365  # Default: 365
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 
 - Terraform >= 1.0
-- AWS provider >= 5.11, < 7.0
+- AWS provider >= 6.0, < 7.0
 - An AWS account with permissions to create VPCs, subnets, route tables,
   internet gateways, NAT gateways, S3 buckets, and VPC peering connections
 - Access to the InfraHouse Terraform registry (`registry.infrahouse.com`)
@@ -27,6 +27,7 @@ module "management" {
   service_name          = "management"
   vpc_cidr_block        = "10.1.0.0/16"
   management_cidr_block = "10.1.0.0/16"
+  replication_region    = "us-east-1"
   subnets = [
     {
       cidr                    = "10.1.0.0/24"
@@ -62,6 +63,7 @@ module "website" {
   service_name          = "website"
   vpc_cidr_block        = "10.3.0.0/16"
   management_cidr_block = "10.1.0.0/16"
+  replication_region    = "us-east-1"
   subnets = [
     {
       cidr                    = "10.3.0.0/24"

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,7 @@ service networks and is used to host common services like bastion hosts, monitor
     - Custom tags
 - Automatic hub-and-spoke peering with a management VPC
 - VPC Flow Logs to S3 with 365-day retention (ISO/SOC compliant)
+- Cross-Region Replication (CRR) of VPC Flow Logs bucket for disaster recovery
 - S3 gateway endpoint for private S3 access
 - Restrictive default security group (configurable)
 - Internet Gateway and optional per-subnet NAT Gateways with Elastic IPs
@@ -42,6 +43,7 @@ module "network" {
   service_name          = "my-service"
   vpc_cidr_block        = "10.1.0.0/16"
   management_cidr_block = "10.1.0.0/16"
+  replication_region    = "us-east-1"
   subnets = [
     {
       cidr                    = "10.1.0.0/24"

--- a/examples/management-network/main.tf
+++ b/examples/management-network/main.tf
@@ -13,7 +13,7 @@ module "management" {
   restrict_all_traffic  = true
   enable_dns_hostnames  = true
   enable_dns_support    = true
-  enable_vpc_flow_logs  = true
+  replication_region    = "us-east-1"
   subnets = [
     {
       cidr                    = "10.1.0.0/24"

--- a/examples/service-network/main.tf
+++ b/examples/service-network/main.tf
@@ -13,7 +13,7 @@ module "website" {
   restrict_all_traffic  = true
   enable_dns_hostnames  = true
   enable_dns_support    = true
-  enable_vpc_flow_logs  = true
+  replication_region    = "us-east-1"
   subnets = [
     {
       cidr                    = "10.2.0.0/24"

--- a/outputs.tf
+++ b/outputs.tf
@@ -51,6 +51,6 @@ output "route_table_all_ids" {
 }
 
 output "vpc_flow_bucket_name" {
-  description = "S3 bucket name with VPC Flow logs if enabled"
-  value       = var.enable_vpc_flow_logs ? aws_s3_bucket.vpc_flow_logs[0].bucket : null
+  description = "S3 bucket name with VPC Flow logs"
+  value       = aws_s3_bucket.vpc_flow_logs[0].bucket
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.11, < 7.0"
+      version = ">= 6.0, < 7.0"
     }
   }
 }

--- a/test_data/service_network/main.tf
+++ b/test_data/service_network/main.tf
@@ -11,8 +11,8 @@ module "test_network" {
   management_cidr_block   = var.management_cidr_block
   subnets                 = var.subnets
   restrict_all_traffic    = var.restrict_all_traffic
-  enable_vpc_flow_logs    = var.enable_vpc_flow_logs
   flow_logs_force_destroy = true
+  replication_region      = var.replication_region
   tags = {
     test_id : random_string.test-id.result
   }

--- a/test_data/service_network/variables.tf
+++ b/test_data/service_network/variables.tf
@@ -49,7 +49,6 @@ variable "restrict_all_traffic" {
   type = bool
 }
 
-variable "enable_vpc_flow_logs" {
-  type    = bool
-  default = false
+variable "replication_region" {
+  type = string
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,6 @@ from textwrap import dedent
 
 from infrahouse_core.logging import setup_logging
 
-
 LOG = logging.getLogger()
 setup_logging(LOG, debug=True)
 TERRAFORM_ROOT_DIR = "test_data"
@@ -21,6 +20,16 @@ def update_source(path, module_path):
             fp.write(line)
 
 
+def _pick_replication_region(region: str) -> str:
+    candidates = [
+        "us-east-1",
+        "us-east-2",
+        "us-west-1",
+        "us-west-2",
+    ]
+    return next(r for r in candidates if r != region)
+
+
 @contextmanager
 def create_tf_conf(
     tf_dir,
@@ -30,24 +39,19 @@ def create_tf_conf(
     subnets,
     zone_names: list,
     restrict_all_traffic: bool,
-    enable_vpc_flow_logs: bool = False,
     test_role_arn: str = None,
     keep_after: bool = False,
 ):
     config_file = osp.join(tf_dir, "terraform.tfvars")
     try:
         with open(config_file, "w") as fd:
-            fd.write(
-                dedent(
-                    f"""
+            fd.write(dedent(f"""
                     region = "{region}"
                     management_cidr_block = "{management_cidr_block}"
                     vpc_cidr_block = "{vpc_cidr_block}"
                     restrict_all_traffic = {str(restrict_all_traffic).lower()}
-                    enable_vpc_flow_logs = {str(enable_vpc_flow_logs).lower()}
-                    """
-                )
-            )
+                    replication_region = "{_pick_replication_region(region)}"
+                    """))
             subnets_fmt = f"subnets = {subnets}"
             fd.write(
                 subnets_fmt.format(
@@ -61,13 +65,9 @@ def create_tf_conf(
                 )
             )
             if test_role_arn:
-                fd.write(
-                    dedent(
-                        f"""
+                fd.write(dedent(f"""
                         role_arn      = "{test_role_arn}"
-                        """
-                    )
-                )
+                        """))
 
         LOG.info(
             "Terraform configuration: %s",

--- a/tests/test_one_vpc.py
+++ b/tests/test_one_vpc.py
@@ -12,9 +12,7 @@ from pytest_infrahouse import terraform_apply
 from tests.conftest import create_tf_conf, TERRAFORM_ROOT_DIR
 
 
-@pytest.mark.parametrize(
-    "aws_provider_version", ["~> 5.11", "~> 6.0"], ids=["aws-5", "aws-6"]
-)
+@pytest.mark.parametrize("aws_provider_version", ["~> 6.0"], ids=["aws-6"])
 @pytest.mark.parametrize(
     ", ".join(
         [
@@ -26,7 +24,6 @@ from tests.conftest import create_tf_conf, TERRAFORM_ROOT_DIR
             "expected_subnet_public_count",
             "expected_subnet_private_count",
             "restrict_all_traffic",
-            "enable_vpc_flow_logs",
         ]
     ),
     [
@@ -39,7 +36,6 @@ from tests.conftest import create_tf_conf, TERRAFORM_ROOT_DIR
             0,  # expected_subnet_public_count
             0,  # expected_subnet_private_count
             False,  # restrict_all_traffic
-            False,  # enable_vpc_flow_logs
             id="no_subnets",
         ),
         pytest.param(
@@ -51,7 +47,6 @@ from tests.conftest import create_tf_conf, TERRAFORM_ROOT_DIR
             0,  # expected_subnet_public_count
             0,  # expected_subnet_private_count
             True,  # restrict_all_traffic
-            False,  # enable_vpc_flow_logs
             id="no_subnets_restricted",
         ),
         pytest.param(
@@ -72,7 +67,6 @@ from tests.conftest import create_tf_conf, TERRAFORM_ROOT_DIR
             1,  # expected_subnet_public_count
             0,  # expected_subnet_private_count
             False,  # restrict_all_traffic
-            False,  # enable_vpc_flow_logs
             id="one_subnet",
         ),
         pytest.param(
@@ -107,7 +101,6 @@ from tests.conftest import create_tf_conf, TERRAFORM_ROOT_DIR
             1,  # expected_subnet_public_count
             2,  # expected_subnet_private_count
             True,  # restrict_all_traffic
-            True,  # enable_vpc_flow_logs
             id="three_subnets_with_nat",
         ),
         pytest.param(
@@ -142,7 +135,6 @@ from tests.conftest import create_tf_conf, TERRAFORM_ROOT_DIR
             2,  # expected_subnet_public_count
             2,  # expected_subnet_private_count
             True,  # restrict_all_traffic
-            False,  # enable_vpc_flow_logs
             id="four_subnets_one_nat",
         ),
     ],
@@ -157,7 +149,6 @@ def test_service_network(
     expected_subnet_public_count,
     expected_subnet_private_count,
     restrict_all_traffic,
-    enable_vpc_flow_logs,
     keep_after,
     test_role_arn,
     boto3_session,
@@ -174,9 +165,7 @@ def test_service_network(
 
     terraform_tf_path = osp.join(terraform_module_dir, "terraform.tf")
     with open(terraform_tf_path, "w") as fp:
-        fp.write(
-            dedent(
-                f"""
+        fp.write(dedent(f"""
                     terraform {{
                       required_providers {{
                         aws = {{
@@ -189,9 +178,7 @@ def test_service_network(
                         }}
                       }}
                     }}
-                    """
-            )
-        )
+                    """))
 
     ec2 = boto3_session.client("ec2", region_name=aws_region)
     response = ec2.describe_availability_zones(
@@ -209,7 +196,6 @@ def test_service_network(
         vpc_cidr_block=vpc_cidr_block,
         subnets=subnets,
         restrict_all_traffic=restrict_all_traffic,
-        enable_vpc_flow_logs=enable_vpc_flow_logs,
         test_role_arn=test_role_arn,
         zone_names=zone_names,
         keep_after=keep_after,
@@ -278,9 +264,7 @@ def test_service_network(
                 )
                 with timeout(120):
                     while True:
-                        exit_code = instance.execute_command(
-                            "ping -c 1 google.com"
-                        )[0]
+                        exit_code = instance.execute_command("ping -c 1 google.com")[0]
                         if exit_code == 0:
                             break
                         sleep(10)

--- a/variables.tf
+++ b/variables.tf
@@ -83,12 +83,6 @@ variable "subnets" {
   }
 }
 
-variable "enable_vpc_flow_logs" {
-  description = "Whether to enable VPC Flow Logs. Default, true."
-  type        = bool
-  default     = true
-}
-
 variable "flow_logs_force_destroy" {
   description = "Whether to force destroy the VPC flow logs S3 bucket and all its contents on deletion."
   type        = bool
@@ -102,6 +96,19 @@ variable "vpc_cidr_block" {
   validation {
     condition     = can(cidrhost(var.vpc_cidr_block, 0))
     error_message = "vpc_cidr_block must be a valid IPv4 CIDR block (e.g., 10.0.0.0/16)"
+  }
+}
+
+variable "replication_region" {
+  description = "AWS region for cross-region replication of the VPC flow logs bucket."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z]{2}(-[a-z]+-[0-9]+)$", var.replication_region))
+    error_message = <<-EOT
+      replication_region must be a valid AWS region name
+      (e.g., us-east-1, eu-west-2). Got: ${var.replication_region}
+    EOT
   }
 }
 

--- a/vpc_flow_logs.tf
+++ b/vpc_flow_logs.tf
@@ -1,5 +1,5 @@
 resource "aws_flow_log" "vpc" {
-  count                = var.enable_vpc_flow_logs ? 1 : 0
+  count                = 1
   log_destination      = aws_s3_bucket.vpc_flow_logs[count.index].arn
   log_destination_type = "s3"
   traffic_type         = "ALL"
@@ -8,14 +8,14 @@ resource "aws_flow_log" "vpc" {
 }
 
 resource "aws_s3_bucket" "vpc_flow_logs" {
-  count         = var.enable_vpc_flow_logs ? 1 : 0
+  count         = 1
   bucket_prefix = "vpc-flow-logs-${replace(var.service_name, " ", "-")}-"
   force_destroy = var.flow_logs_force_destroy
   tags          = local.default_module_tags
 }
 
 resource "aws_s3_bucket_public_access_block" "public_access" {
-  count                   = var.enable_vpc_flow_logs ? 1 : 0
+  count                   = 1
   bucket                  = aws_s3_bucket.vpc_flow_logs[count.index].id
   block_public_acls       = true
   block_public_policy     = true
@@ -24,7 +24,7 @@ resource "aws_s3_bucket_public_access_block" "public_access" {
 }
 
 resource "aws_s3_bucket_versioning" "enabled" {
-  count  = var.enable_vpc_flow_logs ? 1 : 0
+  count  = 1
   bucket = aws_s3_bucket.vpc_flow_logs[count.index].id
   versioning_configuration {
     status = "Enabled"
@@ -32,7 +32,7 @@ resource "aws_s3_bucket_versioning" "enabled" {
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "default" {
-  count  = var.enable_vpc_flow_logs ? 1 : 0
+  count  = 1
   bucket = aws_s3_bucket.vpc_flow_logs[count.index].id
   rule {
     apply_server_side_encryption_by_default {
@@ -43,7 +43,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "default" {
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "vpc_flow_logs" {
-  count  = var.enable_vpc_flow_logs ? 1 : 0
+  count  = 1
   bucket = aws_s3_bucket_versioning.enabled[count.index].bucket
   rule {
     id     = "delete-old"
@@ -61,13 +61,13 @@ resource "aws_s3_bucket_lifecycle_configuration" "vpc_flow_logs" {
 }
 
 resource "aws_s3_bucket_policy" "vpc_flow_logs" {
-  count  = var.enable_vpc_flow_logs ? 1 : 0
+  count  = 1
   bucket = aws_s3_bucket.vpc_flow_logs[count.index].id
   policy = data.aws_iam_policy_document.vpc_flow_logs[count.index].json
 }
 
 data "aws_iam_policy_document" "vpc_flow_logs" {
-  count = var.enable_vpc_flow_logs ? 1 : 0
+  count = 1
   statement {
     sid    = "AllowSSLRequestsOnly"
     effect = "Deny"

--- a/vpc_flow_logs_replication.tf
+++ b/vpc_flow_logs_replication.tf
@@ -146,6 +146,8 @@ resource "aws_s3_bucket_replication_configuration" "vpc_flow_logs" {
     id     = "replicate-all"
     status = "Enabled"
 
+    filter {}
+
     destination {
       bucket        = aws_s3_bucket.vpc_flow_logs_replica.arn
       storage_class = "STANDARD_IA"

--- a/vpc_flow_logs_replication.tf
+++ b/vpc_flow_logs_replication.tf
@@ -148,6 +148,10 @@ resource "aws_s3_bucket_replication_configuration" "vpc_flow_logs" {
 
     filter {}
 
+    delete_marker_replication {
+      status = "Enabled"
+    }
+
     destination {
       bucket        = aws_s3_bucket.vpc_flow_logs_replica.arn
       storage_class = "STANDARD_IA"

--- a/vpc_flow_logs_replication.tf
+++ b/vpc_flow_logs_replication.tf
@@ -1,0 +1,169 @@
+resource "aws_s3_bucket" "vpc_flow_logs_replica" {
+  region        = var.replication_region
+  bucket_prefix = "vpc-flow-logs-${replace(var.service_name, " ", "-")}-replica-"
+  force_destroy = var.flow_logs_force_destroy
+  tags          = local.default_module_tags
+}
+
+resource "aws_s3_bucket_public_access_block" "vpc_flow_logs_replica" {
+  region                  = var.replication_region
+  bucket                  = aws_s3_bucket.vpc_flow_logs_replica.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_versioning" "vpc_flow_logs_replica" {
+  region = var.replication_region
+  bucket = aws_s3_bucket.vpc_flow_logs_replica.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "vpc_flow_logs_replica" {
+  region = var.replication_region
+  bucket = aws_s3_bucket.vpc_flow_logs_replica.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+    bucket_key_enabled = true
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "vpc_flow_logs_replica" {
+  region = var.replication_region
+  bucket = aws_s3_bucket.vpc_flow_logs_replica.id
+  rule {
+    id     = "delete-old"
+    status = "Enabled"
+    filter {
+      object_size_greater_than = 0
+    }
+    expiration {
+      days = var.vpc_flow_retention_days
+    }
+    noncurrent_version_expiration {
+      noncurrent_days = var.vpc_flow_retention_days
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "vpc_flow_logs_replica" {
+  region = var.replication_region
+  bucket = aws_s3_bucket.vpc_flow_logs_replica.id
+  policy = data.aws_iam_policy_document.vpc_flow_logs_replica.json
+}
+
+data "aws_iam_policy_document" "vpc_flow_logs_replica" {
+  statement {
+    sid    = "AllowSSLRequestsOnly"
+    effect = "Deny"
+    actions = [
+      "s3:*",
+    ]
+    resources = [
+      aws_s3_bucket.vpc_flow_logs_replica.arn,
+      "${aws_s3_bucket.vpc_flow_logs_replica.arn}/*",
+    ]
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "replication_assume_role" {
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["s3.amazonaws.com"]
+    }
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "replication" {
+  name_prefix        = "vpc-flow-logs-crr-"
+  assume_role_policy = data.aws_iam_policy_document.replication_assume_role.json
+  tags               = local.default_module_tags
+}
+
+data "aws_iam_policy_document" "replication" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:GetReplicationConfiguration",
+      "s3:ListBucket",
+    ]
+    resources = [
+      aws_s3_bucket.vpc_flow_logs[0].arn,
+    ]
+  }
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:GetObjectVersionForReplication",
+      "s3:GetObjectVersionAcl",
+      "s3:GetObjectVersionTagging",
+    ]
+    resources = [
+      "${aws_s3_bucket.vpc_flow_logs[0].arn}/*",
+    ]
+  }
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:ReplicateObject",
+      "s3:ReplicateDelete",
+      "s3:ReplicateTags",
+    ]
+    resources = [
+      "${aws_s3_bucket.vpc_flow_logs_replica.arn}/*",
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "replication" {
+  name   = "replication"
+  role   = aws_iam_role.replication.id
+  policy = data.aws_iam_policy_document.replication.json
+}
+
+resource "aws_s3_bucket_replication_configuration" "vpc_flow_logs" {
+  bucket = aws_s3_bucket.vpc_flow_logs[0].id
+  role   = aws_iam_role.replication.arn
+
+  rule {
+    id     = "replicate-all"
+    status = "Enabled"
+
+    destination {
+      bucket        = aws_s3_bucket.vpc_flow_logs_replica.arn
+      storage_class = "STANDARD_IA"
+    }
+  }
+
+  lifecycle {
+    precondition {
+      condition     = var.replication_region != data.aws_region.current.name
+      error_message = <<-EOT
+        replication_region must be different from the current region
+        (${data.aws_region.current.name}). Got: ${var.replication_region}
+      EOT
+    }
+  }
+
+  depends_on = [
+    aws_s3_bucket_versioning.enabled,
+    aws_s3_bucket_versioning.vpc_flow_logs_replica,
+  ]
+}


### PR DESCRIPTION
## Summary

- Add Cross-Region Replication (CRR) to the VPC flow logs S3 bucket using AWS provider v6 `region` argument (no provider aliases)
- New required variable `replication_region` specifies the DR target region
- Remove `enable_vpc_flow_logs` variable — flow logs are now always enabled (compliance requirement)
- Bump AWS provider minimum from 5.11 to 6.0

**Breaking changes** (major version bump required):
- `replication_region` is a new required variable
- `enable_vpc_flow_logs` has been removed
- Existing flow logs resources use `count = 1` to preserve state addresses — no `terraform state mv` needed

Resolves: INF-1547

## Test plan

- [ ] `terraform fmt --check -recursive` passes
- [ ] `pytest -xvvs tests/test_one_vpc.py -k "aws-6-three_subnets_with_nat"` — validates CRR with flow logs
- [ ] `terraform plan` on existing deployments shows only new replication resources, no bucket recreation
- [ ] Verify replica bucket is created in the specified replication region
- [ ] Verify replication configuration is active on source bucket

🤖 Generated with [Claude Code](https://claude.com/claude-code)