### PR TITLE
fix: truncate flow logs replica bucket_prefix to 37-char AWS limit

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default reviewers for all pull requests
+* @akuzminsky

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,13 +20,14 @@ make lint           # Check Terraform formatting: terraform fmt --check -recursi
 ```
 
 Tests are pytest-based integration tests that deploy real AWS infrastructure.
-They use `pytest-infrahouse` fixtures and `infrahouse-core` helpers. Tests are
-parametrized across AWS provider versions (~5.11 and ~6.0). Expect long run
-times (CI timeout is 120 minutes).
+They use `pytest-infrahouse` fixtures and `infrahouse-core` helpers. Tests run
+against AWS provider ~6.0 only (the module requires `>= 6.0, < 7.0`). Expect
+long run times (CI timeout is 120 minutes).
 
-Run a single test scenario:
+Run a single test scenario (scenario ids: `no_subnets`, etc. — see the
+`pytest.param` ids in `tests/test_one_vpc.py`):
 ```bash
-pytest -xvvs tests/test_one_vpc.py -k "aws-5-management_cidr_block0"
+pytest -xvvs tests/test_one_vpc.py -k no_subnets
 ```
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -14,6 +14,22 @@ A Terraform module that creates isolated AWS VPC "service networks" with an opti
 management network peering topology. Each service network is an island where instances
 can communicate internally and with the outside world, but not with other service networks.
 
+## Why This Module?
+
+Generic VPC modules give you a VPC and leave the network topology up to you. This module
+encodes an opinionated, security-first topology instead:
+
+- **Isolation by design** — every service network is an island. Two service networks cannot
+  reach each other directly, so a compromise of one service does not expose the others.
+- **Hub-and-spoke without the wiring** — point a service network at the management CIDR and
+  the module creates the VPC peering connection and all routes on both sides. No separate
+  peering module, no manual route management.
+- **Compliance built in** — VPC Flow Logs to S3 with 365-day retention, cross-region
+  replication of the log bucket, TLS-only bucket policies, and a default security group
+  that denies all traffic — aligned with ISO 27001 and SOC 2 requirements out of the box.
+- **Tested against real AWS** — every change is verified by integration tests that deploy
+  actual VPCs, EC2 instances, and peering connections.
+
 ## Features
 
 - Creates a VPC with configurable CIDR block and DNS settings
@@ -56,7 +72,20 @@ module "network" {
 ## Documentation
 
 Full documentation is available at
-[infrahouse.github.io/terraform-aws-service-network](https://infrahouse.github.io/terraform-aws-service-network/).
+[infrahouse.github.io/terraform-aws-service-network](https://infrahouse.github.io/terraform-aws-service-network/):
+
+- [Getting Started](https://infrahouse.github.io/terraform-aws-service-network/getting-started/) —
+  prerequisites and first deployment
+- [Configuration](https://infrahouse.github.io/terraform-aws-service-network/configuration/) —
+  all variables explained
+- [Architecture](https://infrahouse.github.io/terraform-aws-service-network/architecture/) —
+  how the module works
+- [Examples](https://infrahouse.github.io/terraform-aws-service-network/examples/) —
+  common use cases
+- [Troubleshooting](https://infrahouse.github.io/terraform-aws-service-network/troubleshooting/) —
+  common issues and fixes
+- [Changelog](https://infrahouse.github.io/terraform-aws-service-network/changelog/) —
+  release history
 
 ## Usage
 
@@ -148,7 +177,7 @@ a working example used in integration tests.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0, < 7.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.59.0 |
 
 ## Modules
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,128 @@
+# Architecture
+
+This document explains how the service-network module works internally.
+
+## Overview
+
+![Architecture](assets/architecture.svg)
+
+The module creates one VPC per invocation. The kind of network it builds is determined by
+comparing two input variables:
+
+- `management_cidr_block == vpc_cidr_block` — this is the **management network** (the hub)
+- `management_cidr_block != vpc_cidr_block` — this is a **service network** (a spoke) that
+  automatically peers with the management VPC
+
+## Hub-and-Spoke Topology
+
+```mermaid
+graph TB
+    subgraph management["Management VPC (10.1.0.0/16)"]
+        bastion[Bastion]
+        monitoring[Monitoring]
+    end
+
+    subgraph website["Service VPC: website (10.2.0.0/16)"]
+        web[Web servers]
+    end
+
+    subgraph database["Service VPC: database (10.3.0.0/16)"]
+        db[MySQL]
+    end
+
+    management <-- "VPC peering" --> website
+    management <-- "VPC peering" --> database
+    website x-. "no direct path" .-x database
+```
+
+Service networks are isolated from each other by design — there is no route between two
+service VPCs. Shared infrastructure (bastion hosts, monitoring, CI runners) lives in the
+management network, which can reach every spoke.
+
+## Components
+
+Each component lives in its own Terraform file.
+
+### VPC (`main.tf`)
+
+The `aws_vpc` resource with configurable DNS support and DNS hostnames. The VPC is tagged
+with `management = true/false` so it can be identified later, and uses
+`create_before_destroy` so CIDR changes do not leave dependent networks without a hub.
+
+### Subnets (`subnets.tf`)
+
+Subnets are created with `for_each` over the `subnets` input variable, keyed by CIDR.
+A subnet is **public** when `map_public_ip_on_launch = true`, otherwise **private**.
+Per-subnet tags are merged with the module-wide tags.
+
+### Routing (`routing.tf`)
+
+Every subnet gets its own route table:
+
+- The VPC's default route table sends `0.0.0.0/0` to the Internet Gateway.
+- Public subnets get a `0.0.0.0/0` route to the Internet Gateway.
+- Private subnets with `forward_to` set get a `0.0.0.0/0` route to the NAT Gateway in the
+  subnet named by `forward_to`.
+- Private subnets without `forward_to` get no internet route at all.
+
+For service networks, the module additionally creates peering routes in **both**
+directions: a route to `management_cidr_block` in every subnet's route table, and a route
+to this VPC's CIDR in every route table of the management VPC.
+
+### Gateways (`gateways.tf`)
+
+An Internet Gateway is always created. A NAT Gateway with an Elastic IP is created in
+every subnet that sets `create_nat = true`. The subnet hosting a NAT Gateway must be
+public (`map_public_ip_on_launch = true`), otherwise the NAT Gateway has no path to the
+internet.
+
+### VPC Peering (`peering.tf`)
+
+Service networks look up the management VPC by its CIDR block with a data source and
+create an auto-accepted `aws_vpc_peering_connection` to it. This requires the management
+VPC to exist in the same account and region before a service network is applied.
+
+### VPC Flow Logs (`vpc_flow_logs.tf`)
+
+Flow logs for the whole VPC are delivered to a dedicated S3 bucket. The bucket:
+
+- denies non-TLS access via bucket policy,
+- has versioning enabled,
+- expires log objects after `vpc_flow_retention_days` (365 by default, per ISO/SOC
+  requirements).
+
+### Cross-Region Replication (`vpc_flow_logs_replication.tf`)
+
+The flow logs bucket is replicated to a second bucket in `replication_region` for
+disaster recovery. Replicated objects are stored in the `STANDARD_IA` storage class and
+expire on the same schedule as the source. A dedicated IAM role grants S3 the minimum
+permissions needed for replication. `replication_region` must differ from the region the
+module is deployed in — this is enforced by a precondition.
+
+### S3 Gateway Endpoint (`vpc_endpoint.tf`)
+
+A gateway-type VPC endpoint for S3 is created and associated with every subnet's route
+table, so S3 traffic (including flow log delivery) stays on the AWS network.
+
+### Default Security Group (`security_groups.tf`)
+
+By default (`restrict_all_traffic = true`) the VPC's default security group has no rules,
+denying all traffic. Setting `restrict_all_traffic = false` allows all traffic within the
+VPC CIDR (or `default_security_group_cidr` if set).
+
+## Route Tables in Detail
+
+For a private subnet `10.2.1.0/24` in a service network `10.2.0.0/16` with
+`forward_to = "10.2.0.0/24"` and a management network `10.1.0.0/16`, the route table
+looks like this:
+
+| Destination            | Target                 | Purpose                    |
+|------------------------|------------------------|----------------------------|
+| `10.2.0.0/16`          | local                  | VPC-internal traffic       |
+| `0.0.0.0/0`            | NAT Gateway            | Outbound internet access   |
+| `10.1.0.0/16`          | VPC peering connection | Management network traffic |
+| S3 prefix list         | S3 gateway endpoint    | Private S3 access          |
+
+The same subnet in a management network would have no peering route; instead, every route
+table in the management VPC receives routes to each service network's CIDR through the
+respective peering connection.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,1 @@
+../CHANGELOG.md

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,150 @@
+# Examples
+
+Working, deployable examples live in the
+[examples/](https://github.com/infrahouse/terraform-aws-service-network/tree/main/examples)
+directory of the repository. This page walks through the common use cases.
+
+## Management Network (the Hub)
+
+The management network must exist before any service network. A network is a management
+network when `management_cidr_block` equals `vpc_cidr_block`:
+
+```hcl
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+module "management" {
+  source  = "registry.infrahouse.com/infrahouse/service-network/aws"
+  version = "5.0.1"
+
+  environment           = "production"
+  service_name          = "management"
+  vpc_cidr_block        = "10.1.0.0/16"
+  management_cidr_block = "10.1.0.0/16"
+  replication_region    = "us-east-1"
+  subnets = [
+    {
+      cidr                    = "10.1.0.0/24"
+      availability_zone       = data.aws_availability_zones.available.names[0]
+      map_public_ip_on_launch = true
+      create_nat              = true
+    },
+    {
+      cidr              = "10.1.1.0/24"
+      availability_zone = data.aws_availability_zones.available.names[1]
+      forward_to        = "10.1.0.0/24"
+    }
+  ]
+}
+```
+
+## Service Network (a Spoke)
+
+A service network uses its own `vpc_cidr_block` and points `management_cidr_block` at the
+hub. The module creates the VPC peering connection and routes on both sides automatically:
+
+```hcl
+module "website" {
+  source  = "registry.infrahouse.com/infrahouse/service-network/aws"
+  version = "5.0.1"
+
+  environment           = "production"
+  service_name          = "website"
+  vpc_cidr_block        = "10.2.0.0/16"
+  management_cidr_block = "10.1.0.0/16" # the hub's CIDR
+  replication_region    = "us-east-1"
+  subnets = [
+    {
+      cidr                    = "10.2.0.0/24"
+      availability_zone       = data.aws_availability_zones.available.names[0]
+      map_public_ip_on_launch = true
+      create_nat              = true
+    },
+    {
+      cidr              = "10.2.1.0/24"
+      availability_zone = data.aws_availability_zones.available.names[1]
+      forward_to        = "10.2.0.0/24"
+    }
+  ]
+}
+```
+
+## Standalone Network
+
+For a single VPC with no peering at all, declare it as its own management network
+(`management_cidr_block = vpc_cidr_block`). No peering resources are created.
+
+## High-Availability NAT (one per AZ)
+
+A single NAT Gateway is a single point of failure and incurs cross-AZ data charges. For
+production workloads, create one NAT per availability zone and forward each private
+subnet to the NAT in its own AZ:
+
+```hcl
+subnets = [
+  # Public subnets, one NAT each
+  {
+    cidr                    = "10.2.0.0/24"
+    availability_zone       = "us-west-2a"
+    map_public_ip_on_launch = true
+    create_nat              = true
+  },
+  {
+    cidr                    = "10.2.1.0/24"
+    availability_zone       = "us-west-2b"
+    map_public_ip_on_launch = true
+    create_nat              = true
+  },
+  # Private subnets, each using the NAT in the same AZ
+  {
+    cidr              = "10.2.10.0/24"
+    availability_zone = "us-west-2a"
+    forward_to        = "10.2.0.0/24"
+  },
+  {
+    cidr              = "10.2.11.0/24"
+    availability_zone = "us-west-2b"
+    forward_to        = "10.2.1.0/24"
+  }
+]
+```
+
+## Fully Isolated Subnets
+
+A subnet with neither `map_public_ip_on_launch`, `create_nat`, nor `forward_to` has no
+route to the internet — only VPC-internal and management peering traffic. Useful for
+databases:
+
+```hcl
+subnets = [
+  {
+    cidr              = "10.2.20.0/24"
+    availability_zone = "us-west-2a"
+  }
+]
+```
+
+## Custom Tags
+
+Tags can be applied module-wide and per subnet:
+
+```hcl
+module "website" {
+  # ...
+
+  tags = {
+    team = "platform"
+  }
+
+  subnets = [
+    {
+      cidr              = "10.2.0.0/24"
+      availability_zone = "us-west-2a"
+      tags = {
+        tier = "frontend"
+      }
+    }
+  ]
+}
+```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,99 @@
+# Troubleshooting
+
+Common issues when deploying the module and how to resolve them.
+
+## `replication_region must be different from the current region`
+
+```text
+Error: Resource precondition failed
+
+  replication_region must be different from the current region
+  (us-west-2). Got: us-west-2
+```
+
+**Cause:** Cross-region replication of the flow logs bucket requires a destination in a
+different region than the one the module is deployed in.
+
+**Fix:** Set `replication_region` to any other AWS region, e.g. `us-east-1`.
+
+## `expected length of bucket_prefix to be in the range (0 - 37)`
+
+```text
+Error: expected length of bucket_prefix to be in the range (0 - 37),
+got vpc-flow-logs-service-network-replica-
+```
+
+**Cause:** In module versions 5.0.0–5.0.1, a `service_name` longer than 14 characters
+produced a replica bucket prefix that exceeded the AWS limit
+([#46](https://github.com/infrahouse/terraform-aws-service-network/issues/46)).
+
+**Fix:** Upgrade to a module release that includes the fix (see the
+[changelog](changelog.md)), or shorten `service_name` to 14 characters or fewer.
+
+## `Each subnet must specify either availability_zone or availability-zone`
+
+**Cause:** A subnet object in the `subnets` list is missing an availability zone.
+
+**Fix:** Add `availability_zone` to every subnet. The dash-spelled `availability-zone`
+attribute is deprecated but still accepted for backward compatibility.
+
+## `no matching EC2 VPC found` for the management VPC
+
+```text
+Error: no matching EC2 VPC found
+
+  with module.website.data.aws_vpc.management_vpc[0]
+```
+
+**Cause:** A service network looks up the management VPC by `management_cidr_block`. The
+lookup fails when the management network does not exist yet, was created with a different
+CIDR, or lives in a different account or region.
+
+**Fix:** Deploy the management network first (in the same account and region), and make
+sure `management_cidr_block` exactly matches its `vpc_cidr_block`.
+
+## `multiple EC2 VPCs matched`
+
+**Cause:** More than one VPC in the account/region has the CIDR block given in
+`management_cidr_block`, so the module cannot tell which one is the hub.
+
+**Fix:** Use a unique CIDR block for the management VPC, or remove the duplicate VPC.
+
+## `terraform destroy` fails with `BucketNotEmpty`
+
+```text
+Error: deleting S3 Bucket (vpc-flow-logs-...): BucketNotEmpty
+```
+
+**Cause:** The flow logs buckets accumulate log objects (and object versions), which S3
+refuses to delete implicitly.
+
+**Fix:** Set `flow_logs_force_destroy = true` and apply before destroying. Intended for
+test and development environments; for production, keep the logs and let lifecycle rules
+expire them.
+
+## Instances in a private subnet cannot reach the internet
+
+**Cause:** Private subnets only get an internet route when `forward_to` points at a
+subnet with a NAT Gateway. Also note that a NAT Gateway must live in a *public* subnet
+(`map_public_ip_on_launch = true`) — a NAT in a private subnet has no path to the
+Internet Gateway.
+
+**Fix:** Set `create_nat = true` on a public subnet and `forward_to = "<that subnet's
+cidr>"` on each private subnet that needs outbound access.
+
+## Instances cannot communicate at all
+
+**Cause:** By default (`restrict_all_traffic = true`) the VPC's default security group
+denies all traffic, per compliance requirements.
+
+**Fix:** Attach purpose-built security groups to your instances (recommended), or set
+`restrict_all_traffic = false` to allow all traffic within the VPC CIDR.
+
+## `Warning: Deprecated attribute` for `data.aws_region.current.name`
+
+**Cause:** AWS provider 6.x deprecated the `name` attribute of the `aws_region` data
+source in favor of `region`. Module versions up to 5.0.1 still reference `name`.
+
+**Fix:** The warning is harmless. Upgrade to a module release that includes the fix to
+silence it.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,10 @@ nav:
   - Home: index.md
   - Getting Started: getting-started.md
   - Configuration: configuration.md
+  - Architecture: architecture.md
+  - Examples: examples.md
+  - Troubleshooting: troubleshooting.md
+  - Changelog: changelog.md
 
 markdown_extensions:
   - pymdownx.highlight:

--- a/test_data/service_network/variables.tf
+++ b/test_data/service_network/variables.tf
@@ -15,7 +15,9 @@ variable "role_arn" {
 variable "service_name" {
   description = "Descriptive name of a service that will use this VPC"
   type        = string
-  default     = "my service"
+  # Longer than 14 characters so tests exercise the replica bucket_prefix
+  # truncation (https://github.com/infrahouse/terraform-aws-service-network/issues/46)
+  default = "my longer service"
 }
 
 variable "management_cidr_block" {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,14 @@
 import logging
 import os
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from os import path as osp
+from subprocess import CalledProcessError
 
 from textwrap import dedent
+from typing import Iterator
 
 from infrahouse_core.logging import setup_logging
+from pytest_infrahouse import terraform_apply
 
 LOG = logging.getLogger()
 setup_logging(LOG, debug=True)
@@ -18,6 +21,47 @@ def update_source(path, module_path):
         for line in lines:
             line = line.replace("%SOURCE%", module_path)
             fp.write(line)
+
+
+@contextmanager
+def terraform_apply_with_retries(
+    path: str, max_attempts: int = 3, **kwargs
+) -> Iterator[dict]:
+    """
+    Wrap ``pytest_infrahouse.terraform_apply``, retrying the apply phase.
+
+    Works around transient AWS errors, most notably ``PutBucketReplication``
+    failing with ``MissingRequestBodyError`` shortly after bucket creation
+    (https://github.com/infrahouse/terraform-aws-s3-bucket/issues/27).
+    A failed apply is destroyed by ``terraform_apply`` itself, so every
+    attempt starts from a clean slate. Only the apply phase is retried;
+    exceptions raised by the test body propagate immediately, and the
+    teardown (destroy) runs once via the exit stack.
+
+    :param path: Path to a directory with the terraform root module.
+    :type path: str
+    :param max_attempts: Total number of apply attempts before giving up.
+    :type max_attempts: int
+    :param kwargs: Passed through to ``terraform_apply``.
+    :return: Context manager yielding the ``terraform_apply`` result.
+    :raise CalledProcessError: if the apply fails ``max_attempts`` times.
+    """
+    with ExitStack() as stack:
+        tf_out = None
+        for attempt in range(1, max_attempts + 1):
+            try:
+                tf_out = stack.enter_context(terraform_apply(path, **kwargs))
+                break
+            except CalledProcessError as err:
+                if attempt >= max_attempts:
+                    raise
+                LOG.warning(
+                    "terraform apply attempt %d/%d failed: %s. Retrying...",
+                    attempt,
+                    max_attempts,
+                    err,
+                )
+        yield tf_out
 
 
 def _pick_replication_region(region: str) -> str:

--- a/tests/test_one_vpc.py
+++ b/tests/test_one_vpc.py
@@ -7,9 +7,11 @@ from time import sleep
 import pytest
 from infrahouse_core.aws.ec2_instance import EC2Instance
 from infrahouse_core.timeout import timeout
-from pytest_infrahouse import terraform_apply
-
-from tests.conftest import create_tf_conf, TERRAFORM_ROOT_DIR
+from tests.conftest import (
+    create_tf_conf,
+    terraform_apply_with_retries,
+    TERRAFORM_ROOT_DIR,
+)
 
 
 @pytest.mark.parametrize("aws_provider_version", ["~> 6.0"], ids=["aws-6"])
@@ -200,7 +202,7 @@ def test_service_network(
         zone_names=zone_names,
         keep_after=keep_after,
     ):
-        with terraform_apply(
+        with terraform_apply_with_retries(
             terraform_module_dir,
             json_output=True,
             var_file="terraform.tfvars",

--- a/vpc_endpoint.tf
+++ b/vpc_endpoint.tf
@@ -1,6 +1,6 @@
 resource "aws_vpc_endpoint" "s3" {
   vpc_id            = aws_vpc.vpc.id
-  service_name      = "com.amazonaws.${data.aws_region.current.name}.s3"
+  service_name      = "com.amazonaws.${data.aws_region.current.region}.s3"
   vpc_endpoint_type = "Gateway"
   tags = merge(
     {

--- a/vpc_flow_logs.tf
+++ b/vpc_flow_logs.tf
@@ -102,7 +102,7 @@ data "aws_iam_policy_document" "vpc_flow_logs" {
     condition {
       test = "ArnLike"
       values = [
-        "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+        "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:*"
       ]
       variable = "aws:SourceArn"
     }
@@ -145,7 +145,7 @@ data "aws_iam_policy_document" "vpc_flow_logs" {
     condition {
       test = "ArnLike"
       values = [
-      "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"]
+      "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:*"]
       variable = "aws:SourceArn"
     }
     condition {

--- a/vpc_flow_logs_replication.tf
+++ b/vpc_flow_logs_replication.tf
@@ -1,6 +1,7 @@
 resource "aws_s3_bucket" "vpc_flow_logs_replica" {
-  region        = var.replication_region
-  bucket_prefix = "vpc-flow-logs-${replace(var.service_name, " ", "-")}-replica-"
+  region = var.replication_region
+  # AWS limits bucket_prefix to 37 characters
+  bucket_prefix = substr("vpc-flow-logs-${replace(var.service_name, " ", "-")}-replica-", 0, 37)
   force_destroy = var.flow_logs_force_destroy
   tags = merge(
     local.default_module_tags,
@@ -168,10 +169,10 @@ resource "aws_s3_bucket_replication_configuration" "vpc_flow_logs" {
 
   lifecycle {
     precondition {
-      condition     = var.replication_region != data.aws_region.current.name
+      condition     = var.replication_region != data.aws_region.current.region
       error_message = <<-EOT
         replication_region must be different from the current region
-        (${data.aws_region.current.name}). Got: ${var.replication_region}
+        (${data.aws_region.current.region}). Got: ${var.replication_region}
       EOT
     }
   }


### PR DESCRIPTION
## Summary

Two changes, one commit each:

### fix: replica `bucket_prefix` exceeds the 37-char AWS limit (fixes #46)

- Truncate the flow logs replica `bucket_prefix` with `substr()` so `service_name`
  longer than 14 characters can apply. Backward-compatible: names ≤ 14 chars produce
  an identical prefix, and longer names could never apply before, so no existing
  bucket is replaced.
- Lengthen the test `service_name` to 17 characters so integration tests exercise
  the truncation path.
- Replace deprecated `data.aws_region.current.name` with `.region` (module requires
  AWS provider >= 6.0), silencing the deprecation warnings on every plan.

### docs: implement Terraform module requirements (#41)

- README: add "Why This Module?" section and per-page documentation links
- GitHub Pages: add `architecture.md`, `examples.md`, `troubleshooting.md`, and a
  `changelog.md` symlink; extend the mkdocs nav accordingly
- Add `.github/CODEOWNERS`
- CLAUDE.md: tests run against AWS provider `~> 6.0` only

Intentionally **not** included from the #41 checklist: tfsec scanning and issue/PR
templates.

## Testing

- `terraform validate` clean (no warnings) with AWS provider 6.59.0
- `terraform fmt --check -recursive` clean
- `mkdocs build --strict` passes with the new pages
- Both `examples/` configurations `init` + `validate` successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)